### PR TITLE
KEP-647: Update Api Server Tracing to 1.27 for beta

### DIFF
--- a/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
+++ b/keps/sig-instrumentation/647-apiserver-tracing/kep.yaml
@@ -21,10 +21,10 @@ see-also:
 replaces:
 stage: beta
 last-updated: 2022-09-29
-latest-milestone: "v1.26"
+latest-milestone: "v1.27"
 milestone:
   alpha: "v1.22"
-  beta: "v1.26"
+  beta: "v1.27"
 feature-gates:
   - name: APIServerTracing
 disable-supported: true


### PR DESCRIPTION
One-line PR description: Update beta version to 1.27

Issue link: https://github.com/kubernetes/enhancements/issues/647

Other comments: APIServer tracing did not graduate in 1.26 because of a bug in the version of OpenTelemetry we were using: https://github.com/kubernetes/kubernetes/issues/113791